### PR TITLE
User experience improvements

### DIFF
--- a/docwriter/__main__.py
+++ b/docwriter/__main__.py
@@ -126,6 +126,7 @@ def main():
         sys.exit(3)
 
     utils.check_output()
+    utils.create_markdown_dir()
 
     # create context and processor
     source_processor = sources.SourceProcessor()

--- a/docwriter/__main__.py
+++ b/docwriter/__main__.py
@@ -84,6 +84,12 @@ def main():
         metavar="PRE",
         help="set documentation prefix, as in '-p ft2'",
     )
+    parser.add_argument(
+        "-s",
+        "--site",
+        metavar="DIR",
+        help="set 'site_dir' in mkdocs.yml [default=site]",
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "-q",
@@ -109,6 +115,9 @@ def main():
 
     if args.prefix:
         project_prefix = args.prefix
+
+    if args.site:
+        utils.site_dir = args.site
 
     if args.quiet:
         log_level = logging.ERROR

--- a/docwriter/siteconfig.py
+++ b/docwriter/siteconfig.py
@@ -37,9 +37,8 @@ log = logging.getLogger( __name__ )
 # Config file name
 config_filename = "mkdocs.yml"
 
-# Docs directory and site directory
+# Docs directory
 docs_dir = "markdown"
-site_dir = "site"
 
 # Basic site configuration default values
 site_name        = "FreeType API Reference"
@@ -150,7 +149,7 @@ class  SiteConfig( object ):
         self.site_desc   = site_description
         self.site_author = site_author
         self.docs_dir    = docs_dir
-        self.site_dir    = site_dir
+        self.site_dir    = utils.site_dir
         self.theme_conf  = theme_conf
         self.use_dir_url = use_dir_url
 
@@ -209,8 +208,7 @@ class  SiteConfig( object ):
             self.site_config['site_author'] = self.site_author
         if docs_dir:
             self.site_config['docs_dir'] = self.docs_dir
-        if site_dir:
-            self.site_config['site_dir'] = self.site_dir
+        self.site_config['site_dir'] = self.site_dir
         if use_dir_url is not None:
             self.site_config['use_directory_urls'] = self.use_dir_url
 

--- a/docwriter/utils.py
+++ b/docwriter/utils.py
@@ -104,6 +104,13 @@ def  check_output():
             output_dir = None
 
 
+def  create_markdown_dir():
+    """Create 'markdown' directory if it does not exist."""
+    path = output_dir + os.sep + markdown_dir
+    if not os.path.exists( path ):
+        os.makedirs( path )
+
+
 def  file_exists( pathname ):
     """Check that a given file exists."""
     result = 1

--- a/docwriter/utils.py
+++ b/docwriter/utils.py
@@ -29,6 +29,7 @@ log = logging.getLogger( __name__ )
 #
 output_dir = None
 markdown_dir = "markdown"
+site_dir = "site"
 
 def build_message():
     """Print build message to console."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@
 This module contains tests for functions in `utils.py`.
 """
 
+import os
 import sys
 
 from docwriter import utils
@@ -65,5 +66,12 @@ def test_make_file_list( tmpdir ):
     out_list = [f for f in out_list]
     for i in range( len( expected ) ):
         assert expected[i] in out_list[i]
+
+def test_create_markdown_dir( tmpdir ):
+    utils.output_dir = str( tmpdir )
+    utils.markdown_dir = "markdown_test"
+    expected_path = str( tmpdir ) + os.sep + "markdown_test"
+    utils.create_markdown_dir()
+    assert os.path.exists( expected_path )
 
 # eof


### PR DESCRIPTION
FreeType's API reference is currently produced in `docs/reference/site`, which is inconsistent with the rest of the documentation. The path also causes broken hyperlinks in existing documentation and the API itself.

When the static site exists in `docs/reference`, all hyperlinks function correctly.

I have filed a bug about various documentation issues upstream and have been asked to resolve the problems reported. Many relate to `mkdocs-material` and are being addressed in that project.

The patches in this PR go some way to resolving the issues identified in FreeType's documentation, although a small patch is needed. In this PR, the patches:
- automatically create the 'markdown' directory if it does not exist in the `output` dir; and
- allow users to specify the name of the static site (`site_dir`).