### PR TITLE
Fix code blocks after Markdown 3.2 release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+docwriter-1.2.1 (2020-02-29)
+
+  * Fix code blocks after Markdown 3.2 release.
+  * Fix incompatible dependency of Markdown.
+
 docwriter-1.2 (2019-12-09)
 
   * Automatically create the 'markdown' directory if it does not exist.

--- a/docs/reference/markdown/stylesheets/extra.css
+++ b/docs/reference/markdown/stylesheets/extra.css
@@ -10,18 +10,13 @@
 }
 p {
     text-align: justify;
-   /* margin: 1.5ex 0 1.5ex 0;
-    */
 }
-/* .md-typeset p{
-    margin: 1em 1em 0 1em;
-}
-*/
+
 /* code blocks */
 pre.colored {
     color: blue;
 }
-pre {
+pre>code {
     font-family: monospace;
     background-color: #D6E8FF;
     padding: 2ex 0 2ex 1%;
@@ -33,16 +28,18 @@ span.keyword {
     white-space: pre;
     color: #d73a49;
 }
+.md-typeset pre>code {
+    white-space: pre;
+}
 /* H4 Heading */
 h4 {
     background-color: #EEEEFF;
     font-size: medium;
     font-style: oblique;
     font-weight: bold;
-   /* margin: 3ex 0 1.5ex 9%;
-    */
     padding: 0.3em 0 0.3em 1%;
 }
+
 /* Fields table */
 table.fields {
     width: 90%;
@@ -67,7 +64,7 @@ table.fields td.desc p {
     margin: 1.5ex 0 0 0;
 }
 
-/* START EXPERIMENTAL CODE */
+/* Define 'long' tables */
 table.long {
     display: block;
     width: 93%;
@@ -112,42 +109,8 @@ table.long td:before {
     padding-right: 10px;
     white-space: nowrap;
 }
-/* END EXPERIMENTAL CODE */
+/* End 'long' table definition */
 
-/* Index table */
-table.index {
-    width: 100%;
-    border-collapse: collapse;
-    border: 0;
-    border-spacing: 1em 0.3ex;
-}
-table.index tr {
-    padding: 0;
-}
-table.index td {
-    padding: 0;
-}
-table.index-toc-link {
-    width: 100%;
-    border: 0;
-    border-spacing: 0;
-    margin: 1ex 0 1ex 0;
-}
-table.index-toc-link td.left {
-    padding: 0 0.5em 0 0.5em;
-    font-size: 83%;
-    text-align: left;
-}
-table.index-toc-link td.middle {
-    padding: 0 0.5em 0 0.5em;
-    font-size: 83%;
-    text-align: center;
-}
-table.index-toc-link td.right {
-    padding: 0 0.5em 0 0.5em;
-    font-size: 83%;
-    text-align: right;
-}
 /* toc table */
 table.toc {
     width: 95%;
@@ -175,7 +138,9 @@ table.toc td.desc p {
 div.timestamp {
     font-size: small;
 }
-/* Max width before this PARTICULAR table gets nasty This query will take effect for any screen smaller than 760px and also iPads specifically. */
+
+/* Change table layout for smaller screens. This query will take effect for any screen smaller than
+   760px and also iPads specifically. */
 @media only screen and (max-width: 760px), (min-device-width: 768px) and (max-device-width: 1024px) {
    /* Force table to not be like tables anymore */
     table, thead, tbody, th, td, tr {

--- a/docwriter/tomarkdown.py
+++ b/docwriter/tomarkdown.py
@@ -20,6 +20,8 @@ This module subclasses `formatter` and implements syntax-specific
 routines to build markdown output.
 """
 
+from __future__ import print_function
+
 import logging
 import os
 import re
@@ -81,11 +83,13 @@ description_footer = ""
 
 # Source code extracts header/footer.
 source_header = """
-<div class = "codehilite">
+<div class = "codehilite">\
 <pre>\
+<code>\
 """
 source_footer = """\
-</pre>
+</code>\
+</pre>\
 </div>\
 """
 
@@ -598,7 +602,7 @@ class  MdFormatter( Formatter ):
             if header:
                 print( 'Defined in ' + header + '.' )
 
-            print( source_header )
+            print( source_header, end='' )
             for l in block.code:
                 print( self.source_quote( l, block.name ) )
             print( source_footer )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@
 # Direct project dependencies
 mistune==0.8.4
 mkdocs==1.0.4
-mkdocs-material==4.6.0
+mkdocs-material==4.6.3
 PyYAML==5.3


### PR DESCRIPTION
Add `<code>` tag to code blocks written by docwriter, and bump mkdocs-material.

Fixes #36.
