### PR TITLE
Drop support for Python < 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,14 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
 
 # command to install dependencies
 install:
@@ -37,4 +41,4 @@ deploy:
   on:
     tags: true
     repo: freetype/docwriter
-    condition: "$TOXENV = py36"
+    condition: "$TOXENV = py37"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+docwriter-1.3 (2020-03-21)
+
+  * Drop support for Python < 3.5.
+
 docwriter-1.2.1 (2020-02-29)
 
   * Fix code blocks after Markdown 3.2 release.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docwriter is an API documentation generator for the FreeType Library that extrac
 
 ## Installation
 
-Run `pip install docwriter` (see (4) below for an automated `virtualenv` usage). It requires Python 2.7+ or 3.4+ to run.
+Run `pip install docwriter` (see (4) below for an automated `virtualenv` usage). It requires Python >= 3.5 to run.
 
 ## Steps to Generate Docs
 1.  Ensure `docwriter` is installed using `pip`.

--- a/docwriter/__main__.py
+++ b/docwriter/__main__.py
@@ -5,7 +5,7 @@
 #    Convert source code markup to Markdown documentation.
 #
 #  Copyright (C) 2002-2020 by
-#  David Turner.
+#  David Turner, Nikhil Ramakrishnan.
 #
 #  This file is part of the FreeType project, and may only be used,
 #  modified, and distributed under the terms of the FreeType project
@@ -26,17 +26,15 @@
 """This libaray is used to Convert source code markup to Markdown
 documentation."""
 
-from __future__ import print_function
-
 import argparse
 import logging
 import sys
 
-from docwriter import check
-from docwriter import content
-from docwriter import sources
-from docwriter import tomarkdown
-from docwriter import utils
+# TODO: Remove this check at some point in the future.
+if sys.version_info[0] < 3:
+    raise ImportError('Python >= 3.5 is required.')
+
+from docwriter import check, content, sources, tomarkdown, utils
 
 logger = logging.getLogger()
 log_level = logging.INFO

--- a/docwriter/content.py
+++ b/docwriter/content.py
@@ -15,13 +15,10 @@
 """This module contains routines to parse documentation comment blocks,
 building more structured objects out of them."""
 
-from __future__ import print_function
-
 import logging
 import re
 
-from docwriter import sources
-from docwriter import utils
+from docwriter import sources, utils
 
 log = logging.getLogger( __name__ )
 
@@ -95,7 +92,7 @@ re_header_macro = re.compile( r'^#define\s{1,}(\w{1,}_H)\s{1,}<(.*)>' )
 ##  The object is filled line by line by the parser; it strips the leading
 ##  `margin' space from each input line before storing it in `self.lines'.
 ##
-class  DocCode( object ):
+class  DocCode:
 
     def  __init__( self, margin, lines, lang = None ):
         self.lines = []
@@ -129,7 +126,7 @@ class  DocCode( object ):
 ##
 ##  `self.words' contains the list of words that make up the paragraph.
 ##
-class  DocPara( object ):
+class  DocPara:
 
     def  __init__( self, lines, margin = -1 ):
         self.lines  = None
@@ -192,7 +189,7 @@ class  DocPara( object ):
 ##  `DocCode' objects.  Each DocField object also has an optional `name'
 ##  that is used when the object corresponds to a field or value definition.
 ##
-class  DocField( object ):
+class  DocField:
 
     def  __init__( self, name, lines ):
         self.name  = name  # can be `None' for normal paragraphs/sources
@@ -306,7 +303,7 @@ re_field = re.compile( r"""
 ##
 ##  DOC MARKUP CLASS
 ##
-class  DocMarkup( object ):
+class  DocMarkup:
 
     def  __init__( self, tag, lines ):
         self.tag    = tag.lower()
@@ -355,7 +352,7 @@ class  DocMarkup( object ):
 ##
 ##  DOC CHAPTER CLASS
 ##
-class  DocChapter( object ):
+class  DocChapter:
 
     def  __init__( self, block ):
         self.block    = block
@@ -374,7 +371,7 @@ class  DocChapter( object ):
 ##
 ##  DOC SECTION CLASS
 ##
-class  DocSection( object ):
+class  DocSection:
 
     def  __init__( self, name = "Other" ):
         self.name        = name
@@ -414,7 +411,7 @@ class  DocSection( object ):
 ##
 ##  CONTENT PROCESSOR CLASS
 ##
-class  ContentProcessor( object ):
+class  ContentProcessor:
 
     def  __init__( self ):
         """Initialize a block content processor."""
@@ -571,7 +568,7 @@ class  ContentProcessor( object ):
 ##
 ##  DOC BLOCK CLASS
 ##
-class  DocBlock( object ):
+class  DocBlock:
 
     def  __init__( self, source, follow, processor ):
         processor.reset()

--- a/docwriter/formatter.py
+++ b/docwriter/formatter.py
@@ -33,7 +33,7 @@ log = logging.getLogger( __name__ )
 ##
 ##  FORMATTER CLASS
 ##
-class  Formatter( object ):
+class  Formatter:
 
     def  __init__( self, processor ):
         self.processor   = processor

--- a/docwriter/siteconfig.py
+++ b/docwriter/siteconfig.py
@@ -23,8 +23,6 @@ More information can be found at:
 <https://www.mkdocs.org/user-guide/configuration/>
 """
 
-from __future__ import print_function
-
 import datetime
 import logging
 
@@ -113,7 +111,7 @@ def build_extras():
     yml_other     = add_config( other_config, "other" )
 
 
-class  Chapter( object ):
+class  Chapter:
     def __init__( self, title ):
         self.title = title
         self.pages = []
@@ -131,7 +129,7 @@ class  Chapter( object ):
         return conf
 
 
-class  SiteConfig( object ):
+class  SiteConfig:
     """Site configuration generator class.
 
     This class is used to generate site configuration based on supplied

--- a/docwriter/sources.py
+++ b/docwriter/sources.py
@@ -29,8 +29,6 @@ in file `content.py'; the classes and methods found here only deal with
 text parsing and basic documentation block extraction.
 """
 
-from __future__ import print_function
-
 import fileinput
 import logging
 import re
@@ -50,7 +48,7 @@ log = logging.getLogger( __name__ )
 ##  Later on, paragraphs are converted to long lines, which simplifies the
 ##  regular expressions that act upon the text.
 ##
-class  SourceBlockFormat( object ):
+class  SourceBlockFormat:
 
     def  __init__( self, iden, start, column, end ):
         """Create a block pattern, used to recognize special documentation
@@ -263,7 +261,7 @@ re_source_keywords = re.compile( '''\\b ( typedef   |
 ##      other blocks (i.e., sources or ordinary comments with no starting
 ##      markup tag)
 ##
-class  SourceBlock( object ):
+class  SourceBlock:
 
     def  __init__( self, processor, filename, lineno, lines ):
         self.processor = processor
@@ -324,7 +322,7 @@ class  SourceBlock( object ):
 ##    - Normal sources lines, including comments.
 ##
 ##
-class  SourceProcessor( object ):
+class  SourceProcessor:
 
     def  __init__( self ):
         """Initialize a source processor."""

--- a/docwriter/tomarkdown.py
+++ b/docwriter/tomarkdown.py
@@ -20,8 +20,6 @@ This module subclasses `formatter` and implements syntax-specific
 routines to build markdown output.
 """
 
-from __future__ import print_function
-
 import logging
 import os
 import re

--- a/docwriter/utils.py
+++ b/docwriter/utils.py
@@ -116,7 +116,7 @@ def  file_exists( pathname ):
     """Check that a given file exists."""
     result = 1
     try:
-        file_handle = open( pathname, "r" )
+        file_handle = open( pathname )
         file_handle.close()
     except Exception:
         result = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@
 
 # Direct project dependencies
 mistune==0.8.4
-mkdocs==1.0.4
+mkdocs==1.1
 mkdocs-material==4.6.3
-PyYAML==5.3
+PyYAML==5.3.1

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     packages = find_packages(),
     include_package_data = True,
     install_requires = install_requires,
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37, py38
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR tracks changes needed to drop support for Python < 3.5. These versions reached their end-of-life, and no security and bug fixes will be provided for them in the future.

Moreover, mkdocs 1.1 has dropped support for these versions and docwriter must do so to have the latest updates.