### PR TITLE
Add regression tests for docwriter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,21 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - os: linux
+      language: python
+      sudo: required
+      python: 3.7
+      env: TOXENV=regression
+
+  allow_failures:
+    - env: TOXENV=regression
+
+  fast_finish: true
 
 # command to install dependencies
+before-install:
+  - if [ "$TOXENV" = "regression" ]; then sudo apt-get -qq update && sudo apt-get install -y clang autoconf cmake libtool; fi
+
 install:
   - pip install tox
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+master
+
+  * Add regression tests.
+
 docwriter-1.3 (2020-03-21)
 
   * Drop support for Python < 3.5.

--- a/README.md
+++ b/README.md
@@ -3,47 +3,59 @@
 
 # FreeType Docwriter
 
-Docwriter is an API documentation generator for the FreeType Library that extracts and builds Markdown docs from the FreeType header files.
+Docwriter is an API documentation generator for the FreeType Library that extracts and builds
+Markdown docs from the FreeType header files.
 
 ## Installation
 
-Run `pip install docwriter` (see (4) below for an automated `virtualenv` usage). It requires Python >= 3.5 to run.
+Run `pip install docwriter` (see (4) below for an automated `virtualenv` usage). It requires
+Python >= 3.5 to run.
 
 ## Steps to Generate Docs
 1.  Ensure `docwriter` is installed using `pip`.
-2.  Clone the freetype2 repository from [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/).
+
+2.  Clone the freetype2 repository from
+    [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/).
+
 3.  The FreeType build system can be used to generate the docs:
 
-    ```
+    ```bash
     sh autogen.sh
     ./configure
     make refdoc
     ```
-4. Alternatively, step 1 and the make target can be replaced with `make refdoc-venv`. This installs all requirements automatically in a separate virtual environment. More information on `virtualenv` usage can be found [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/README).
+
+4. Alternatively, step 1 and the make target can be replaced with `make refdoc-venv`. This installs
+   all requirements automatically in a separate virtual environment. More information on
+   `virtualenv` usage can be found
+   [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/README).
 
 ## Development Usage
 1.  Clone this repository.
-2.  Clone the freetype2 repository from [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/).
+2.  Clone the freetype2 repository from
+    [here](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/).
 3.  Run `pip install -r requirements.txt` in your environment (`virtualenv` recommended).
 4.  Copy the `include/` directory from `freetype2` to `docwriter`.
 5.  Run in the `docwriter` directory:
 
     ```bash
-		python -m docwriter                      \
-			--prefix=ft2                     \
-			--title=FreeType-2.9.1           \
-			--site=reference                 \
-			--output=./docs                  \
-			./include/freetype/*.h           \
-			./include/freetype/config/*.h    \
-			./include/freetype/cache/*.h
+    python -m docwriter                      \
+            --prefix=ft2                     \
+            --title=FreeType-2.9.1           \
+            --site=reference                 \
+            --output=./docs                  \
+            ./include/freetype/*.h           \
+            ./include/freetype/config/*.h    \
+            ./include/freetype/cache/*.h
     ```
-6.  The markdown files are generated in `docs/markdown/`. Static site can be built by running `mkdocs build` in `docs/`. Read more about Mkdocs [here](https://www.mkdocs.org/#building-the-site).
+6.  The markdown files are generated in `docs/markdown/`. Static site can be built by running
+    `mkdocs build` in `docs/`. Read more about Mkdocs
+    [here](https://www.mkdocs.org/#building-the-site).
 
 ## Usage Information
 
 ```
-docwriter [-h] [-t T] -o DIR [-p PRE] [-q | -v] files [files ...]
+docwriter [-h] [-t T] -o DIR [-p PRE] [-s DIR] [-q | -v] files [files ...]
 
 DocWriter Usage information
 
@@ -55,49 +67,48 @@ optional arguments:
   -t T, --title T       set project title, as in '-t "My Project"'
   -o DIR, --output DIR  set output directory, as in '-o mydir'
   -p PRE, --prefix PRE  set documentation prefix, as in '-p ft2'
+  -s DIR, --site DIR    set 'site_dir' in mkdocs.yml [default=site]
   -q, --quiet           run quietly, show only errors
   -v, --verbose         increase output verbosity
 ```
 
 ## Running Tests
 
-There are two possible test scenarios:
-
-1. Running tests on both py27 and py36 (using tox - requires both python versions installed).
-2. Running tests on the currently installed Python version.
-
-They are detailed below.
-
-### Test using Tox
-
-To test on both py27 and py36:
+To test on all supported Python versions:
 
 1.  Make sure `tox` is installed:
     ```bash
     pip install tox
     ```
 
-2.  Ensure both py27 and py36 are available.
+2.  Ensure that all Python versions that you need to run the tests on are installed.
 
 3.  Run tests:
     ```bash
     tox
     ```
 
-### Test on single python version
+To run specifc tests, use the `-e` argument. For example,
 
-To test on current python version using pytest:
+```bash
+tox -e py37,py38
+```
 
-1.  Make sure `pytest` is installed:
-    ```bash
-    pip install pytest
-    ```
+will run tests only on Python 3.7 and 3.8 (assuming they are installed). See [tox.ini](tox.ini) for
+all available environments.
 
-2.  Run tests:
-    ```bash
-    cd tests/
-    python -m pytest
-    ```
+More information on running specific tox environments can be found
+[here](https://tox.readthedocs.io/en/latest/example/general.html#selecting-one-or-more-environments-to-run-tests-against).
+
+### Regression Tests
+
+Regression tests require internet access, `git`, and other FreeType [build
+dependencies](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/README.git), and are
+time-consuming. These tests are largely meant to run on Travis CI, but can also be run locally:
+
+```bash
+tox -e regression
+```
 
 ## License
 
@@ -106,6 +117,6 @@ This library is licensed under the [FreeType License](https://www.freetype.org/l
 ## History
 
 This library was originally written by David Turner as `docmaker` which collected and presented
-documentation in HTML. It has since been modified multiple times, including a major refactor
-to allow multiple output formats. The current `docwriter` is the biggest rewrite, with lots of
-changes and additions that allow it to be more flexible, readable, maintainable and usable.
+documentation in HTML. It has since been modified multiple times, including a major refactor to
+allow multiple output formats. The current `docwriter` is the biggest rewrite, with lots of changes
+and additions that allow it to be more flexible, readable, maintainable and usable.

--- a/tests/freetype.sh
+++ b/tests/freetype.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -exo pipefail
+
+#
+#  freetype.sh
+#
+#    Clone freetype2 and make targets `refdoc' and `refdoc-venv`.
+#
+#  Copyright (C) 2020 by
+#  Nikhil Ramakrishnan.
+#
+#  This file is part of the FreeType project, and may only be used,
+#  modified, and distributed under the terms of the FreeType project
+#  license, LICENSE.TXT.  By continuing to use, modify, or distribute
+#  this file you indicate that you have read the license and
+#  understand and accept it fully.
+
+check_output_dir () {
+    # Count number of files in output directories
+    file_count=$(find "$1" -type f | wc -l)
+
+    echo Number of files in $1 is $file_count
+
+    if [ "$file_count" -eq "0" ]; then
+        echo ERROR: No output files found in $1 1>&2
+        return 1
+    fi
+    return 0
+}
+
+dir="${PWD}"
+
+script_dir=$( dirname $( readlink -f "${0}" ) ) # this is the `tests' dir
+output_dir="$script_dir/output"
+freetype_dir="freetype2"
+path_to_freetype="$output_dir/$freetype_dir"
+docs_dir="docs"
+markdown_dir="$docs_dir/markdown"
+reference_dir="$docs_dir/reference"
+build_dir="freetype2.compile"
+
+cd "$output_dir" # go to `tests/output'
+
+# Clone the latest version of FreeType
+git clone https://git.savannah.gnu.org/git/freetype/freetype2.git $freetype_dir
+
+cd "$freetype_dir"
+
+git clean -dfqx
+git reset --hard
+git rev-parse HEAD
+
+sh autogen.sh
+
+sh configure
+
+#########################################################################
+# Part 1 - Use the docwriter that is already installed
+#########################################################################
+make refdoc
+
+# Come back to freetype2 directory
+cd "$path_to_freetype"
+
+# Check output
+check_output_dir "$markdown_dir"
+res1=$?
+check_output_dir "$reference_dir"
+res2=$?
+
+if [ "$res1" -ne "0" ] || [ "$res2" -ne "0" ]; then
+    exit 1
+fi
+
+# Clean up only the `docs' dir
+cd "$docs_dir"
+git clean -dfqx
+git reset --hard
+cd "$path_to_freetype"
+
+#########################################################################
+# Part 2 - Use a virtual environment
+#########################################################################
+make refdoc-venv
+
+# Come back to freetype2 directory
+cd "$path_to_freetype"
+
+# Check output
+check_output_dir "$markdown_dir"
+res1=$?
+check_output_dir "$reference_dir"
+res2=$?
+
+if [ "$res1" -ne "0" ] || [ "$res2" -ne "0" ]; then
+    exit 1
+fi
+
+# Clean up only the `docs' dir
+cd "$docs_dir"
+git clean -dfqx
+git reset --hard
+cd "$path_to_freetype"
+
+#########################################################################
+# Part 3 - Build docs with `builddir' != `srcdir'
+#########################################################################
+# Configure freetype2 in another directory
+cd ../
+mkdir "$build_dir"
+cd "$build_dir"
+../$freetype_dir/configure
+
+make refdoc
+
+# Come back to `builddir'
+cd "$output_dir/$build_dir"
+
+# Check output
+check_output_dir "$markdown_dir"
+res1=$?
+check_output_dir "$reference_dir"
+res2=$?
+
+if [ "$res1" -ne "0" ] || [ "$res2" -ne "0" ]; then
+    exit 1
+fi
+
+# Final clean up
+cd  "$output_dir"
+rm -rf $freetype_dir $build_dir
+
+cd "$dir"
+
+# eof

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py35, py36, py37, py38
+envlist =
+    py35, py36, py37, py38
 
 [testenv]
 deps =
@@ -9,3 +10,15 @@ changedir =
     tests/
 commands =
     python -m pytest -v
+
+[testenv:regression]
+whitelist_externals=
+    /bin/bash
+    make
+    git
+changedir =
+    tests/
+deps=
+    -r{toxinidir}/requirements.txt
+commands=
+    bash {toxinidir}/tests/freetype.sh


### PR DESCRIPTION
Docwriter will now be tested with the 'freetype2' repository. The tox environment `regression` is used, which runs the script `tests/freetype.sh`, that clones 'freetype2' and configures it. The make targets `refdoc` and `refdoc-venv` are tested, and the docs are also built with `builddir` != `srcdir`.

Currently the test is allowed to fail (this means that the Travis build will be successful even if the regression test fails), but this can be changed later, so that it becomes necessary for regression tests to pass for the build to be successful.

Note that the testenv `regression` is not added to `[envlist]` in `tox.ini` because we don't want it to run by default when `tox` command is invoked locally. This is a long test with many requirements, so we prefer to run it only on Travis.